### PR TITLE
Project service update project when null tracy cummings

### DIFF
--- a/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
+++ b/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
@@ -203,10 +203,13 @@ public class ProjectServiceTestSuite {
 		assertTrue(classUnderTest.updateProject(dummyProject, "97"));
 	}
 	
+	
+	/**
+	 * First block tests for if a project exists, but none of the fields are filled.
+	 * Second block tests for if a project does not exist, will return false. 
+	 */
 	@Test
 	public void testUpdateProjectWhereNotPresent() {
-
-		// Tests for if a project exists, but none of the fields are filled. 
 		optionalProject = Optional.of(dummySavedProject);
 		when(testRepo.findById("97")).thenReturn(optionalProject);
 		when(dummyProject.getName()).thenReturn(null);
@@ -221,7 +224,6 @@ public class ProjectServiceTestSuite {
 		when(dummyProject.getOldProject()).thenReturn(null);
 		assertTrue(classUnderTest.updateProject(dummyProject, "97"));
 		
-		// Tests for if a project does not exist, will return false. 
 		assertFalse(classUnderTest.updateProject(dummyProject,dummyString));
 	}
 	

--- a/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
+++ b/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
@@ -222,8 +222,7 @@ public class ProjectServiceTestSuite {
 		assertTrue(classUnderTest.updateProject(dummyProject, "97"));
 		
 		// Tests for if a project does not exist, will return false. 
-		System.out.println(classUnderTest.updateProject(dummyProject,dummyString));
-		assertFalse(false);
+		assertFalse(classUnderTest.updateProject(dummyProject,dummyString));
 	}
 	
 	/**

--- a/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
+++ b/src/test/java/com/revature/testing/ProjectServiceTestSuite.java
@@ -1,6 +1,7 @@
 package com.revature.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -200,6 +201,29 @@ public class ProjectServiceTestSuite {
 		when(dummyProject.getStatus()).thenReturn(dummyString);
 		when(dummyProject.getOldProject()).thenReturn(dummySavedProject);
 		assertTrue(classUnderTest.updateProject(dummyProject, "97"));
+	}
+	
+	@Test
+	public void testUpdateProjectWhereNotPresent() {
+
+		// Tests for if a project exists, but none of the fields are filled. 
+		optionalProject = Optional.of(dummySavedProject);
+		when(testRepo.findById("97")).thenReturn(optionalProject);
+		when(dummyProject.getName()).thenReturn(null);
+		when(dummyProject.getBatch()).thenReturn(null);
+		when(dummyProject.getTrainer()).thenReturn(null);
+		when(dummyProject.getGroupMembers()).thenReturn(null);
+		when(dummyProject.getScreenShots()).thenReturn(null);
+		when(dummyProject.getZipLinks()).thenReturn(null);
+		when(dummyProject.getDescription()).thenReturn(null);
+		when(dummyProject.getTechStack()).thenReturn(null);
+		when(dummyProject.getStatus()).thenReturn(null);
+		when(dummyProject.getOldProject()).thenReturn(null);
+		assertTrue(classUnderTest.updateProject(dummyProject, "97"));
+		
+		// Tests for if a project does not exist, will return false. 
+		System.out.println(classUnderTest.updateProject(dummyProject,dummyString));
+		assertFalse(false);
 	}
 	
 	/**


### PR DESCRIPTION
Added a test case for updateProject when there are problems. First block checks for when a project exists, if any of the fields are null. Second block checks for if a project doesn't exist, then return false. 