### PR TITLE
Local noaws storage service mock implementation

### DIFF
--- a/src/main/java/com/revature/services/S3StorageServiceImpl.java
+++ b/src/main/java/com/revature/services/S3StorageServiceImpl.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,6 +18,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.revature.helpers.FileHelper;
 
 @Service
+@Profile(value = {"dev", "prod"})
 public class S3StorageServiceImpl implements StorageService {
 
 	@Value("${aws.config.aws-access-key-id}")

--- a/src/main/java/com/revature/services/S3StorageServiceImpl.java
+++ b/src/main/java/com/revature/services/S3StorageServiceImpl.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.revature.helpers.FileHelper;
 
 @Service
-@Profile({"dev", "prod"})
+@Profile("!local")
 public class S3StorageServiceImpl implements StorageService {
 
 	@Value("${aws.config.aws-access-key-id}")

--- a/src/main/java/com/revature/services/S3StorageServiceImpl.java
+++ b/src/main/java/com/revature/services/S3StorageServiceImpl.java
@@ -18,7 +18,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.revature.helpers.FileHelper;
 
 @Service
-@Profile(value = {"dev", "prod"})
+@Profile({"dev", "prod"})
 public class S3StorageServiceImpl implements StorageService {
 
 	@Value("${aws.config.aws-access-key-id}")

--- a/src/main/java/com/revature/services/StorageLocalMockImpl.java
+++ b/src/main/java/com/revature/services/StorageLocalMockImpl.java
@@ -1,0 +1,31 @@
+package com.revature.services;
+
+import java.io.File;
+
+import org.jboss.logging.Logger;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Profile("local")
+public class StorageLocalMockImpl implements StorageService {
+
+	Logger logger = Logger.getLogger(StorageLocalMockImpl.class);
+	
+	@Override
+	public void init() {
+		logger.warn("Running with mock S3 implementation. This should only be used for a local development environment.");
+	}
+
+	@Override
+	public String store(MultipartFile multipartFile) {
+		return "localhost:8080/unpersisted";
+	}
+
+	@Override
+	public String store(File file) {
+		return "localhost:8080/unpersisted";
+	}
+
+}


### PR DESCRIPTION
### Mock S3 Bean

Adds a new fake StorageService implementation that will be wired when the application runs in the _local_ profile.  Original S3StorageServiceImpl bean has been configured to run when the _local_ profile is not being used.